### PR TITLE
do not reference Stream from Wire

### DIFF
--- a/AZ3166/AZ3166-1.0.0/libraries/Wire/Wire.cpp
+++ b/AZ3166/AZ3166-1.0.0/libraries/Wire/Wire.cpp
@@ -226,7 +226,6 @@ size_t TwoWire::write(uint8_t data)
     // don't bother if buffer is full
     if (txBufferLength >= BUFFER_LENGTH)
     {
-      setWriteError();
       return 0;
     }
     // put byte in tx buffer

--- a/AZ3166/AZ3166-1.0.0/libraries/Wire/Wire.h
+++ b/AZ3166/AZ3166-1.0.0/libraries/Wire/Wire.h
@@ -23,7 +23,6 @@
 #define TwoWire_h
 
 #include <inttypes.h>
-#include "Stream.h"
 #include "i2c_api.h"
 
 #define BUFFER_LENGTH 32
@@ -36,7 +35,7 @@
 #define I2C_OK 0
 #define I2C_TIMEOUT 1
 
-class TwoWire : public Stream
+class TwoWire
 {
   private:
     uint8_t rxBuffer[BUFFER_LENGTH];
@@ -89,7 +88,6 @@ class TwoWire : public Stream
     inline size_t write(long n) { return write((uint8_t)n); }
     inline size_t write(unsigned int n) { return write((uint8_t)n); }
     inline size_t write(int n) { return write((uint8_t)n); }
-    using Print::write;
 };
 
 extern TwoWire Wire;


### PR DESCRIPTION
Same file name Stream.h makes library included header file confusing, do not reference Stream from Wire.