### PR TITLE
add provison config for Scenario 2

### DIFF
--- a/AZ3166/AZ3166-1.0.0/libraries/VoiceToTwitter/examples/VoiceToTwitter/.bin/config.json
+++ b/AZ3166/AZ3166-1.0.0/libraries/VoiceToTwitter/examples/VoiceToTwitter/.bin/config.json
@@ -1,0 +1,9 @@
+{
+  "sketch": "../VoiceToTwitter.ino",
+  "config": "deviceConnectionString",
+  "provision_iot_hub": true,
+  "provision_storage": true,
+  "provision_logic_app": true,
+  "provision_azure_function": false,
+  "functionRelativePath": "azureFunction"
+}


### PR DESCRIPTION
Because azure function in Scenario 2 is different, we should specify type, envs, etc in somewhere. So currently I simply set  `"provision_azure_function": false` to disable further azure function deployment.
I don't know who takes over this part now, feel free to touch me if there's any question in provision/deploy part.