### PR TITLE
Use system wifi config in MQTT client example

### DIFF
--- a/AZ3166/src/libraries/MQTT/examples/MQTTClient/MQTTClient.ino
+++ b/AZ3166/src/libraries/MQTT/examples/MQTTClient/MQTTClient.ino
@@ -10,7 +10,7 @@ bool hasWifi = false;
 const char* mqttServer = "iot.eclipse.org";   //"m2m.eclipse.org";
 int port = 1883;
 
-void InitWiFi()
+void initWifi()
 {
   Screen.print("IoT DevKit\r\n \r\nConnecting...\r\n");
 


### PR DESCRIPTION
Remove configuring Wi-Fi SSID and password in source code, and used System Wi-Fi instead