### PR TITLE
Improve the user experience of network dis-connect / re-connect.

### DIFF
--- a/AZ3166/src/cores/arduino/Telemetry/TelemetryClient.cpp
+++ b/AZ3166/src/cores/arduino/Telemetry/TelemetryClient.cpp
@@ -10,14 +10,15 @@
 #include "SystemWiFi.h"
 #include "TelemetryClient.h"
 
-#define STACK_SIZE 0x1000
+#define STACK_SIZE              0x1000
 
 #ifndef CORRELATIONID
 // Empty 64bit correlation_id
-#define CORRELATIONID "0000000000000000000000000000000000000000000000000000000000000000"
+#define CORRELATIONID           "0000000000000000000000000000000000000000000000000000000000000000"
 #endif
 
-#define CORRELATION_ID_LENGTH 64
+#define CORRELATION_ID_LENGTH   64
+#define CHECK_INTERVAL_MS       5000
 
 static const char *EVENT = "AIEVENT";
 static const char *BODY_TEMPLATE = 
@@ -159,6 +160,13 @@ void TelemetryClient::telemetry_worker(void)
 {
     while (true)
     {
+        if (SystemWiFiRSSI() == 0)
+        {
+            // Cache telemetry data until it's restored
+            wait_ms(CHECK_INTERVAL_MS);
+            continue;
+        }
+        
         char* msg = pop_msg();
         if (msg != NULL)
         {
@@ -167,7 +175,7 @@ void TelemetryClient::telemetry_worker(void)
         }
         else
         {
-            wait_ms(5000);
+            wait_ms(CHECK_INTERVAL_MS);
         }
     }
 }

--- a/AZ3166/src/cores/arduino/system/SystemWiFi.cpp
+++ b/AZ3166/src/cores/arduino/system/SystemWiFi.cpp
@@ -80,6 +80,11 @@ NetworkInterface* WiFiInterface(void)
     return network;
 }
 
+int SystemWiFiRSSI(void)
+{
+    return (int)((EMW10xxInterface*)network)->get_rssi();
+}
+
 int WiFiScan(WiFiAccessPoint *res, unsigned count)
 {
     if (network != NULL)

--- a/AZ3166/src/cores/arduino/system/SystemWiFi.h
+++ b/AZ3166/src/cores/arduino/system/SystemWiFi.h
@@ -12,6 +12,7 @@ extern "C"{
 
 bool InitSystemWiFi(void);
 bool SystemWiFiConnect(void);
+int SystemWiFiRSSI(void);
 const char* SystemWiFiSSID(void);
 NetworkInterface* WiFiInterface(void);
 

--- a/AZ3166/src/libraries/AzureIoT/examples/DevKitTranslator/DevKitTranslator.ino
+++ b/AZ3166/src/libraries/AzureIoT/examples/DevKitTranslator/DevKitTranslator.ino
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. 
+// To get started please visit https://microsoft.github.io/azure-iot-developer-kit/docs/projects/devkit-translator/?utm_source=ArduinoExtension&utm_medium=ReleaseNote&utm_campaign=VSCode
 #include "Arduino.h"
 #include "AudioClass.h"
 #include "AZ3166WiFi.h"

--- a/AZ3166/src/libraries/AzureIoT/examples/DoorMonitor/DoorMonitor.ino
+++ b/AZ3166/src/libraries/AzureIoT/examples/DoorMonitor/DoorMonitor.ino
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. 
+// To get started please visit https://microsoft.github.io/azure-iot-developer-kit/docs/projects/door-monitor?utm_source=ArduinoExtension&utm_medium=ReleaseNote&utm_campaign=VSCode
 #include "LIS2MDLSensor.h"
 #include "AZ3166WiFi.h"
 #include "iothub_client_sample_mqtt.h"

--- a/AZ3166/src/libraries/AzureIoT/examples/GetStarted/GetStarted.ino
+++ b/AZ3166/src/libraries/AzureIoT/examples/GetStarted/GetStarted.ino
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. 
+// To get started please visit https://microsoft.github.io/azure-iot-developer-kit/docs/projects/connect-iot-hub?utm_source=ArduinoExtension&utm_medium=ReleaseNote&utm_campaign=VSCode
 #include "AzureIotHub.h"
 #include "AZ3166WiFi.h"
 #include "config.h"

--- a/AZ3166/src/libraries/AzureIoT/examples/RemoteMonitoring/RemoteMonitoring.ino
+++ b/AZ3166/src/libraries/AzureIoT/examples/RemoteMonitoring/RemoteMonitoring.ino
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. 
+// To get started please visit https://microsoft.github.io/azure-iot-developer-kit/docs/projects/remote-monitoring/?utm_source=ArduinoExtension&utm_medium=ReleaseNote&utm_campaign=VSCode
 #include "Arduino.h"
 #include "Sensor.h"
 #include "AzureIotHub.h"

--- a/AZ3166/src/libraries/AzureIoT/examples/ShakeShake/ShakeShake.ino
+++ b/AZ3166/src/libraries/AzureIoT/examples/ShakeShake/ShakeShake.ino
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. 
+// To get started please visit https://microsoft.github.io/azure-iot-developer-kit/docs/projects/shake-shake/?utm_source=ArduinoExtension&utm_medium=ReleaseNote&utm_campaign=VSCode
 #include "AZ3166WiFi.h"
 #include "AzureIotHub.h"
 #include "IoTHubMQTTClient.h"
@@ -197,7 +198,14 @@ static void ShowShakeProgress()
 static void NoTweets()
 {
   Screen.clean();
-  DrawAppTitle("No tweets...");
+  if (WiFi.status() == WL_CONNECTED)
+  {
+    DrawAppTitle("No tweets...");
+  }
+  else
+  {
+    DrawAppTitle("No Wi-Fi...");
+  }
   Screen.print(3, "Press A to Shake!");
   DrawTweetImage(1, 20, 0);
 

--- a/AZ3166/src/libraries/WiFi/src/AZ3166WiFi.cpp
+++ b/AZ3166/src/libraries/WiFi/src/AZ3166WiFi.cpp
@@ -294,6 +294,10 @@ int WiFiClass::encryptionType(unsigned char networkItem)
 
 unsigned char WiFiClass::status()
 {
+    if (SystemWiFiRSSI() == 0)
+    {
+        return ((current_status == WL_CONNECTED) ? WL_CONNECTION_LOST : WL_DISCONNECTED);
+    }
     return current_status;
 }
 


### PR DESCRIPTION
1. Improve the user experience of network dis-connect / re-connect.
   a. Expose new RSSI API for network status check.
   b. Return the right status in the WiFiClass::status.
   c. Don't re-create IoTHubMQTT client when there is no Wi-Fi.
   d. Function IoTHubMQTT_Check and IoTHubMQTT_SendEvent return immediately if there is no Wi-Fi.
   e. Don't send telemetry data if there is no Wi-Fi.
   f. The ShakeShake app show 'No Wi-Fi' instead of 'No tweet' if there is no Wi-Fi.
2. Add URL in all AZ IoT mini solutions.
