### PR TITLE
Fix the connection issue which cause 'no tweet' (#548)

### DIFF
--- a/AZ3166/src/libraries/AzureIoT/examples/ShakeShake/ShakeShake.ino
+++ b/AZ3166/src/libraries/AzureIoT/examples/ShakeShake/ShakeShake.ino
@@ -42,9 +42,9 @@ static int msgStart = 0;
 // Indicate whether WiFi is ready
 static bool hasWifi = false;
 
-// Time interval check for heart beat
+// The interval time of heart beat
 static uint64_t hb_interval_ms;
-// Time interval check for retrieving the tweet
+// The timeout for retrieving the tweet
 static uint64_t tweet_timeout_ms;
 
 // Shake shake processing status
@@ -289,6 +289,8 @@ static void DoShake()
   acc_gyro->getStepCounter(&steps);
   if (steps > 2)
   {
+    hb_interval_ms = SystemTickCounterRead();
+    
     // Enter the do work mode
     app_status = 2;
     // Shake detected

--- a/AZ3166/src/libraries/AzureIoT/src/IoTHubMQTTClient.cpp
+++ b/AZ3166/src/libraries/AzureIoT/src/IoTHubMQTTClient.cpp
@@ -316,6 +316,7 @@ void IoTHubMQTT_Init(void)
         return;
     }
     
+    // Create the IoTHub client
     if ((iotHubClientHandle = IoTHubClient_LL_CreateFromConnectionString((char*)connString, MQTT_Protocol)) == NULL)
     {
         // Microsoft collects data to operate effectively and provide you the best experiences with our products. 
@@ -323,7 +324,12 @@ void IoTHubMQTT_Init(void)
         send_telemetry_data(iothub_hostname, "Create", "IoT hub establish failed");
         return;
     }
-    int keepalive = 120;
+
+    // Set the interval of 'Keepalive' to 15, the reason is an underlying defect of the Wi-Fi socket interface:
+    //   the telemetry sending is running in another thread, if the current thread can't send a message (socket send) 
+    //   within about 30s after sending a telemetry message, this socket is closed and no API to detect it's status.
+    // Here the workaround is just let the keepalive message be sent more frequently which can bring the socket back.
+    int keepalive = 15;
     IoTHubClient_LL_SetOption(iotHubClientHandle, "keepalive", &keepalive);
     bool traceOn = false;
     IoTHubClient_LL_SetOption(iotHubClientHandle, "logtrace", &traceOn);


### PR DESCRIPTION
* Fix the connection issue which cause 'no tweet' if the DevKit is idled for a long time (around 30s) after shaking a tweet.

Set the interval of 'Keepalive' to 15, the reason is an underlying defect of the Wi-Fi socket interface:
   the telemetry sending is running in another thread, if the current thread can't send a message (socket send)
   within about 30s after sending a telemetry message, this socket is closed and no API to detect it's status.
Here the workaround is just let the keepalive message be sent more frequently which can bring the socket back.

* reset the heart beat timer when start to run a shaking process