### PR TITLE
Re-connect and re-send the messsage if wait confirmation failed. (#552)

### DIFF
--- a/AZ3166/src/cores/arduino/system/SystemWiFi.cpp
+++ b/AZ3166/src/cores/arduino/system/SystemWiFi.cpp
@@ -64,7 +64,7 @@ bool SystemWiFiConnect(void)
 
         // Microsoft collects data to operate effectively and provide you the best experiences with our products. 
         // We collect data about the features you use, how often you use them, and how you use them.
-        send_telemetry_data_async("", "wifi", "Wi-Fi connected");
+        send_telemetry_data_sync("", "wifi", "Wi-Fi connected");
 
         return true;
     }

--- a/AZ3166/src/libraries/AzureIoT/examples/ShakeShake/ShakeShake.ino
+++ b/AZ3166/src/libraries/AzureIoT/examples/ShakeShake/ShakeShake.ino
@@ -42,6 +42,9 @@ static int msgStart = 0;
 // Indicate whether WiFi is ready
 static bool hasWifi = false;
 
+// Indicate whether IoT Hub is ready
+static bool hasIoTHub = false;
+
 // The interval time of heart beat
 static uint64_t hb_interval_ms;
 // The timeout for retrieving the tweet
@@ -308,9 +311,9 @@ static void DoShake()
     {
       if (shake_progress < 2)
       {
-        // Because the tweet may return quickly and the TwitterMessageCallback be executed before run to here,
-        // So check the shake_progress to avoid set the wrong value.
         // IoT hub has got the message
+        // The tweet may return in the TwitterMessageCallback.
+        // So check the shake_progress to avoid set the wrong value.
         shake_progress = 2;
       }
       // Update the screen
@@ -425,7 +428,15 @@ void setup()
 
   Screen.print(3, " > IoT Hub");
   
-  IoTHubMQTT_Init();
+  if (!IoTHubMQTT_Init())
+  {
+    Screen.clean();
+    DrawAppTitle("IoT DevKit");
+    Screen.print(2, "No IoT Hub");
+    hasIoTHub = false;
+    return;
+  }
+  hasIoTHub = true;
   IoTHubMQTT_SetMessageCallback(TwitterMessageCallback);
   
   rgbLed.setColor(RGB_LED_BRIGHTNESS, 0, 0);
@@ -439,7 +450,7 @@ void setup()
 
 void loop()
 {
-  if (hasWifi)
+  if (hasWifi && hasIoTHub)
   {
     switch(app_status)
     {

--- a/AZ3166/src/libraries/AzureIoT/src/IoTHubMQTTClient.h
+++ b/AZ3166/src/libraries/AzureIoT/src/IoTHubMQTTClient.h
@@ -15,7 +15,7 @@ extern "C"
 * @brief	Initialize a IoT Hub MQTT client for communication with an existing IoT hub.
 *           The connection string is load from the EEPROM.
 */
-void IoTHubMQTT_Init(void);
+bool IoTHubMQTT_Init(void);
 
 /**
 * @brief	Asynchronous call to send the message specified by @p text.


### PR DESCRIPTION
* A better fix of https://github.com/Microsoft/AzureIoTDeveloperKit/pull/548 is just re-connect and re-send the messsage if wait confirmation failed.

* Confirm the connection of IoT Hub is ready at begin