### PR TITLE
Telemetry iot hub from pre-release

### DIFF
--- a/AZ3166/src/cores/arduino/az_iot/iothub_client/src/iothub_client_ll.c
+++ b/AZ3166/src/cores/arduino/az_iot/iothub_client/src/iothub_client_ll.c
@@ -19,6 +19,7 @@
 #include "iothub_client_options.h"
 #include "iothub_client_version.h"
 #include <stdint.h>
+#include "Telemetry.h"
 
 #ifndef DONT_USE_UPLOADTOBLOB
 #include "iothub_client_ll_uploadtoblob.h"
@@ -1403,6 +1404,39 @@ void IoTHubClient_LL_ConnectionStatusCallBack(IOTHUB_CLIENT_LL_HANDLE handle, IO
     }
     else
     {
+        // Microsoft collects data to operate effectively and provide you the best experiences with our products. 
+        // We collect data about the features you use, how often you use them, and how you use them.
+        switch(reason)
+        {
+        case IOTHUB_CLIENT_CONNECTION_EXPIRED_SAS_TOKEN:
+            if (status == IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED)
+            {
+                LogInfo(">>>Connection status: timeout");
+            }
+            break;
+        case IOTHUB_CLIENT_CONNECTION_DEVICE_DISABLED:
+            break;
+        case IOTHUB_CLIENT_CONNECTION_BAD_CREDENTIAL:
+            break;
+        case IOTHUB_CLIENT_CONNECTION_RETRY_EXPIRED:
+            break;
+        case IOTHUB_CLIENT_CONNECTION_NO_NETWORK:
+            if (status == IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED)
+            {
+                LogInfo(">>>Connection status: disconnected");
+            }
+            break;
+        case IOTHUB_CLIENT_CONNECTION_COMMUNICATION_ERROR:
+            break;
+        case IOTHUB_CLIENT_CONNECTION_OK:
+            if (status == IOTHUB_CLIENT_CONNECTION_AUTHENTICATED)
+            {
+                LogInfo(">>>Connection status: connected");
+                send_telemetry_data_async("", "Create", "IoT hub established");
+            }
+            break;
+        }
+        
         IOTHUB_CLIENT_LL_HANDLE_DATA* handleData = (IOTHUB_CLIENT_LL_HANDLE_DATA*)handle;
 
         /*Codes_SRS_IOTHUBCLIENT_LL_25_114: [IoTHubClient_LL_ConnectionStatusCallBack shall call non-callback set by the user from IoTHubClient_LL_SetConnectionStatusCallback passing the status, reason and the passed userContextCallback.]*/

--- a/AZ3166/src/cores/arduino/system/SystemVersion.cpp
+++ b/AZ3166/src/cores/arduino/system/SystemVersion.cpp
@@ -7,7 +7,7 @@
 
 #define DEVKIT_MAJOR_VERSION 1
 #define DEVKIT_MINOR_VERSION 1
-#define DEVKIT_PATCH_VERSION 0
+#define DEVKIT_PATCH_VERSION 1
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
A hotfix: Add sending out the ‘IoTHub attach’ telemetry data in azure sdk