### PR TITLE
Fix case for included files

### DIFF
--- a/AZ3166/src/cores/arduino/az_iot/provisioning_client/adapters/secure_device_riot.c
+++ b/AZ3166/src/cores/arduino/az_iot/provisioning_client/adapters/secure_device_riot.c
@@ -11,7 +11,7 @@
 #include "secure_device_riot.h"
 
 #include "RiotCore.h"
-#include "Riot.h"
+#include "RIoT.h"
 #include "RiotCrypt.h"
 #include "RiotDerEnc.h"
 #include "RiotX509Bldr.h"

--- a/AZ3166/src/cores/arduino/az_iot/provisioning_client/deps/RIoT/Reference/RIoT/Core/RiotCore.h
+++ b/AZ3166/src/cores/arduino/az_iot/provisioning_client/deps/RIoT/Reference/RIoT/Core/RiotCore.h
@@ -11,7 +11,7 @@ Confidential Information
 extern "C" {
 #endif
 #include <stdint.h>
-#include "Riot.h"
+#include "RIoT.h"
 #include "RiotDerEnc.h"
 #include "RiotX509Bldr.h"
 

--- a/AZ3166/src/libraries/Audio/src/AudioClass.h
+++ b/AZ3166/src/libraries/Audio/src/AudioClass.h
@@ -5,7 +5,7 @@
 #define __AUDIO_H__
 
 #include "mbed.h"
-#include "NAU88C10.h"
+#include "nau88c10.h"
 
 #define DURATION_IN_SECONDS         2
 #define DEFAULT_SAMPLE_RATE         8000

--- a/AZ3166/src/libraries/AudioV2/src/AudioClassV2.h
+++ b/AZ3166/src/libraries/AudioV2/src/AudioClassV2.h
@@ -5,7 +5,7 @@
 #define __AUDIO_CLASS_V2_H__
 
 #include "mbed.h"
-#include "NAU88C10.h"
+#include "nau88c10.h"
 
 #define DURATION_IN_SECONDS         2
 #define DEFAULT_SAMPLE_RATE         8000

--- a/AZ3166/tools/dice_device_enrollment/src/dice_device_enrollment/RIoT/Core/RiotCore.h
+++ b/AZ3166/tools/dice_device_enrollment/src/dice_device_enrollment/RIoT/Core/RiotCore.h
@@ -11,7 +11,7 @@ Confidential Information
 extern "C" {
 #endif
 #include <stdint.h>
-#include "Riot.h"
+#include "RIoT.h"
 #include "RiotDerEnc.h"
 #include "RiotX509Bldr.h"
 


### PR DESCRIPTION
Case for filename should be respected in #include statements so that sketch can be built on case sensitive operating systems (like Linux)