### PR TITLE
Fix the config_device_connection task in RemoteMonitoringV2

### DIFF
--- a/AZ3166/src/libraries/AzureIoT/examples/RemoteMonitoringv2/.vscode/tasks.json
+++ b/AZ3166/src/libraries/AzureIoT/examples/RemoteMonitoringv2/.vscode/tasks.json
@@ -10,31 +10,6 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "cloud-provision",
-            "command": "node",
-            "windows": {
-                "args": ["\"${env:USERPROFILE}\\azure-board-cli\\out\\cli.js\"", "provision", ".bin"],
-                "options": {
-                    "shell": {
-                        "executable": "cmd.exe",
-                        "args": ["/d", "/c"]
-                    }
-                }
-            },
-            "linux": {
-                "args": ["\"$HOME/azure-board-cli/out/cli.js\"", "provision", ".bin"]
-            },
-            "osx": {
-                "args": ["\"/Users/$USER/azure-board-cli/out/cli.js\"", "provision", ".bin"]
-            },
-            "type": "shell",
-            "presentation": {
-                "reveal": "always",
-                "focus": true
-            },
-            "problemMatcher": []
-        },
-        {
             "taskName": "device-upload",
             "command": "node",
             "windows": {
@@ -64,7 +39,7 @@
             "taskName": "config-device-connection",
             "command": "node",
             "windows": {
-                "args": ["\"${env:USERPROFILE}\\azure-board-cli\\out\\cli.js\"", "config_device_connection", ".bin"],
+                "args": ["\"${env:USERPROFILE}\\azure-board-cli\\out\\cli.js\"", "config_device_connection_string", ".bin"],
                 "options": {
                     "shell": {
                         "executable": "cmd.exe",
@@ -73,10 +48,10 @@
                 }
             },
             "linux": {
-                "args": ["\"$HOME/azure-board-cli/out/cli.js\"", "config_device_connection", ".bin"]
+                "args": ["\"$HOME/azure-board-cli/out/cli.js\"", "config_device_connection_string", ".bin"]
             },
             "osx": {
-                "args": ["\"/Users/$USER/azure-board-cli/out/cli.js\"", "config_device_connection", ".bin"]
+                "args": ["\"/Users/$USER/azure-board-cli/out/cli.js\"", "config_device_connection_string", ".bin"]
             },
             "type": "shell",
             "presentation": {


### PR DESCRIPTION
In RemoteMonitoringV2:
1. Fix the task 'config-device-connection' (#786 The config_device_connection task doesn't work )
2. Remove the usless task 'cloud-provision'
