### PR TITLE
make dice device enrollment tool compiling on linux

### DIFF
--- a/AZ3166/tools/dice_device_enrollment/src/dice_device_enrollment/generateMake.py
+++ b/AZ3166/tools/dice_device_enrollment/src/dice_device_enrollment/generateMake.py
@@ -17,7 +17,7 @@ def generateMakefile(rootdir = '.', outputName = 'dps_cert_gen_mac'):
 
 	includeFlag = ""
 	for a in includePaths: includeFlag += " -I" + a
-	print("CXXFLAGS = -g" + includeFlag)
+	print("CXXFLAGS=-Os -lstdc++ " + includeFlag)
 
 	for a in sourceFiles:
 		if (a[1] != "."):
@@ -25,11 +25,11 @@ def generateMakefile(rootdir = '.', outputName = 'dps_cert_gen_mac'):
 
 	for a in sourceFiles:
 		if a[2].endswith('.cpp'):
-			print("\tc++ -g" + includeFlag + " -c -o " + a[0] + " " + os.path.join(a[1], a[2]))
+			print("\tc++ $(CXXFLAGS) -c -o " + a[0] + " " + os.path.join(a[1], a[2]))
 		else :
-			print("\tgcc -g" + includeFlag + " -c -o " + a[0] + " " + os.path.join(a[1], a[2]))
+			print("\tgcc $(CXXFLAGS) -c -o " + a[0] + " " + os.path.join(a[1], a[2]))
 
-	print("\tcc -o " + outputName + targets)
+	print("\tc++ -o " + outputName + targets)
 	print("\trm *.o")
 
 	print("\nclean:")

--- a/AZ3166/tools/dice_device_enrollment/src/dice_device_enrollment/generateMake.py
+++ b/AZ3166/tools/dice_device_enrollment/src/dice_device_enrollment/generateMake.py
@@ -33,8 +33,8 @@ def generateMakefile(rootdir = '.', outputName = 'dps_cert_gen_mac'):
 	print("\trm *.o")
 
 	print("\nclean:")
-	print("\trm *.o")
-	print("\trm " + outputName)
+	print("\trm -f *.o")
+	print("\trm -f " + outputName)
 
 generateMakefile()
 

--- a/AZ3166/tools/dice_device_enrollment/src/dice_device_enrollment/makefile
+++ b/AZ3166/tools/dice_device_enrollment/src/dice_device_enrollment/makefile
@@ -34,5 +34,5 @@ DiceSha256.o:	./DICE/DiceSha256.c
 	rm *.o
 
 clean:
-	rm *.o
-	rm dps_cert_gen_mac
+	rm -f *.o
+	rm -f dps_cert_gen_mac

--- a/AZ3166/tools/dice_device_enrollment/src/dice_device_enrollment/makefile
+++ b/AZ3166/tools/dice_device_enrollment/src/dice_device_enrollment/makefile
@@ -1,36 +1,36 @@
-dps_cert_gen_mac: dice_device_enrollment.o DiceRIoT.o DiceCore.o DiceSha256.o RiotCore.o def.o RiotAes128.o RiotAesTables.o RiotBase64.o RiotCrypt.o RiotDerEnc.o RiotEcc.o RiotHmac.o RiotKdf.o RiotSha256.o RiotX509Bldr.o
-CXXFLAGS = -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include
-DiceCore.o:	./DICE/DiceCore.c
-DiceSha256.o:	./DICE/DiceSha256.c
+dps_cert_gen_mac: DiceRIoT.o dice_device_enrollment.o RiotCore.o RiotAesTables.o RiotSha256.o RiotEcc.o RiotDerEnc.o def.o RiotAes128.o RiotX509Bldr.o RiotBase64.o RiotHmac.o RiotCrypt.o RiotKdf.o DiceCore.o DiceSha256.o
+CXXFLAGS=-Os -lstdc++  -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include
 RiotCore.o:	./RIoT/Core/RiotCore.c
+RiotAesTables.o:	./RIoT/Core/RIoTCrypt/RiotAesTables.c
+RiotSha256.o:	./RIoT/Core/RIoTCrypt/RiotSha256.c
+RiotEcc.o:	./RIoT/Core/RIoTCrypt/RiotEcc.c
+RiotDerEnc.o:	./RIoT/Core/RIoTCrypt/RiotDerEnc.c
 def.o:	./RIoT/Core/RIoTCrypt/def.c
 RiotAes128.o:	./RIoT/Core/RIoTCrypt/RiotAes128.c
-RiotAesTables.o:	./RIoT/Core/RIoTCrypt/RiotAesTables.c
-RiotBase64.o:	./RIoT/Core/RIoTCrypt/RiotBase64.c
-RiotCrypt.o:	./RIoT/Core/RIoTCrypt/RiotCrypt.c
-RiotDerEnc.o:	./RIoT/Core/RIoTCrypt/RiotDerEnc.c
-RiotEcc.o:	./RIoT/Core/RIoTCrypt/RiotEcc.c
-RiotHmac.o:	./RIoT/Core/RIoTCrypt/RiotHmac.c
-RiotKdf.o:	./RIoT/Core/RIoTCrypt/RiotKdf.c
-RiotSha256.o:	./RIoT/Core/RIoTCrypt/RiotSha256.c
 RiotX509Bldr.o:	./RIoT/Core/RIoTCrypt/RiotX509Bldr.c
-	c++ -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o dice_device_enrollment.o ./dice_device_enrollment.cpp
-	c++ -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o DiceRIoT.o ./DiceRIoT.cpp
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o DiceCore.o ./DICE/DiceCore.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o DiceSha256.o ./DICE/DiceSha256.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotCore.o ./RIoT/Core/RiotCore.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o def.o ./RIoT/Core/RIoTCrypt/def.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotAes128.o ./RIoT/Core/RIoTCrypt/RiotAes128.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotAesTables.o ./RIoT/Core/RIoTCrypt/RiotAesTables.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotBase64.o ./RIoT/Core/RIoTCrypt/RiotBase64.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotCrypt.o ./RIoT/Core/RIoTCrypt/RiotCrypt.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotDerEnc.o ./RIoT/Core/RIoTCrypt/RiotDerEnc.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotEcc.o ./RIoT/Core/RIoTCrypt/RiotEcc.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotHmac.o ./RIoT/Core/RIoTCrypt/RiotHmac.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotKdf.o ./RIoT/Core/RIoTCrypt/RiotKdf.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotSha256.o ./RIoT/Core/RIoTCrypt/RiotSha256.c
-	gcc -g -IRIoT/Core -IDICE -IRIoT -IRIoT/Core/RIoTCrypt/include -c -o RiotX509Bldr.o ./RIoT/Core/RIoTCrypt/RiotX509Bldr.c
-	cc -o dps_cert_gen_mac dice_device_enrollment.o DiceRIoT.o DiceCore.o DiceSha256.o RiotCore.o def.o RiotAes128.o RiotAesTables.o RiotBase64.o RiotCrypt.o RiotDerEnc.o RiotEcc.o RiotHmac.o RiotKdf.o RiotSha256.o RiotX509Bldr.o
+RiotBase64.o:	./RIoT/Core/RIoTCrypt/RiotBase64.c
+RiotHmac.o:	./RIoT/Core/RIoTCrypt/RiotHmac.c
+RiotCrypt.o:	./RIoT/Core/RIoTCrypt/RiotCrypt.c
+RiotKdf.o:	./RIoT/Core/RIoTCrypt/RiotKdf.c
+DiceCore.o:	./DICE/DiceCore.c
+DiceSha256.o:	./DICE/DiceSha256.c
+	c++ $(CXXFLAGS) -c -o DiceRIoT.o ./DiceRIoT.cpp
+	c++ $(CXXFLAGS) -c -o dice_device_enrollment.o ./dice_device_enrollment.cpp
+	gcc $(CXXFLAGS) -c -o RiotCore.o ./RIoT/Core/RiotCore.c
+	gcc $(CXXFLAGS) -c -o RiotAesTables.o ./RIoT/Core/RIoTCrypt/RiotAesTables.c
+	gcc $(CXXFLAGS) -c -o RiotSha256.o ./RIoT/Core/RIoTCrypt/RiotSha256.c
+	gcc $(CXXFLAGS) -c -o RiotEcc.o ./RIoT/Core/RIoTCrypt/RiotEcc.c
+	gcc $(CXXFLAGS) -c -o RiotDerEnc.o ./RIoT/Core/RIoTCrypt/RiotDerEnc.c
+	gcc $(CXXFLAGS) -c -o def.o ./RIoT/Core/RIoTCrypt/def.c
+	gcc $(CXXFLAGS) -c -o RiotAes128.o ./RIoT/Core/RIoTCrypt/RiotAes128.c
+	gcc $(CXXFLAGS) -c -o RiotX509Bldr.o ./RIoT/Core/RIoTCrypt/RiotX509Bldr.c
+	gcc $(CXXFLAGS) -c -o RiotBase64.o ./RIoT/Core/RIoTCrypt/RiotBase64.c
+	gcc $(CXXFLAGS) -c -o RiotHmac.o ./RIoT/Core/RIoTCrypt/RiotHmac.c
+	gcc $(CXXFLAGS) -c -o RiotCrypt.o ./RIoT/Core/RIoTCrypt/RiotCrypt.c
+	gcc $(CXXFLAGS) -c -o RiotKdf.o ./RIoT/Core/RIoTCrypt/RiotKdf.c
+	gcc $(CXXFLAGS) -c -o DiceCore.o ./DICE/DiceCore.c
+	gcc $(CXXFLAGS) -c -o DiceSha256.o ./DICE/DiceSha256.c
+	c++ -o dps_cert_gen_mac DiceRIoT.o dice_device_enrollment.o RiotCore.o RiotAesTables.o RiotSha256.o RiotEcc.o RiotDerEnc.o def.o RiotAes128.o RiotX509Bldr.o RiotBase64.o RiotHmac.o RiotCrypt.o RiotKdf.o DiceCore.o DiceSha256.o
 	rm *.o
 
 clean:


### PR DESCRIPTION
- update both generator py and the makefile
fix is to ensure stdc++ is part of the link process. Other than that, use variable instead of repeating compile time args
- silence `make clean` to ensure `make clean && make` is going to work.

https://github.com/Microsoft/devkit-sdk/issues/930