### PR TITLE
fix compile error in wire.h

### DIFF
--- a/AZ3166/src/libraries/Wire/Wire.cpp
+++ b/AZ3166/src/libraries/Wire/Wire.cpp
@@ -120,7 +120,8 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
 
     // set rx buffer iterator vars
     rxBufferIndex = 0;
-    rxBufferLength = read;
+    //rxBufferLength = read;
+      rxBufferLength = quantity;
 
     return read;
   }
@@ -286,7 +287,7 @@ int TwoWire::read(void)
     value = rxBuffer[rxBufferIndex];
     ++rxBufferIndex;
   }
-
+  
   return value;
 }
 

--- a/AZ3166/src/libraries/Wire/Wire.cpp
+++ b/AZ3166/src/libraries/Wire/Wire.cpp
@@ -115,13 +115,12 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint32_t iaddres
     // perform blocking read into buffer
     //uint8_t read = twi_readFrom(address, rxBuffer, quantity, sendStop);
     uint8_t read = 0;
-    if (I2C_OK == i2c_read(&obj, (int)(address << 1), (char *)rxBuffer, (int)quantity, (int)sendStop))
+    if (WIRE_ERROR != i2c_read(&obj, (int)(address << 1), (char *)rxBuffer, (int)quantity, (int)sendStop))
       read = quantity;
 
     // set rx buffer iterator vars
     rxBufferIndex = 0;
-    //rxBufferLength = read;
-      rxBufferLength = quantity;
+    rxBufferLength = read;
 
     return read;
   }

--- a/AZ3166/src/libraries/Wire/Wire.h
+++ b/AZ3166/src/libraries/Wire/Wire.h
@@ -29,6 +29,8 @@
 
 #define MASTER_ADDRESS 0x33
 
+#define WIRE_ERROR (-1)
+
 // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 

--- a/AZ3166/src/libraries/Wire/Wire.h
+++ b/AZ3166/src/libraries/Wire/Wire.h
@@ -73,6 +73,7 @@ class TwoWire
     unsigned char requestFrom(unsigned char, unsigned char);
     unsigned char requestFrom(unsigned char, unsigned char, unsigned char);
 	  unsigned char requestFrom(unsigned char, unsigned char, unsigned int, unsigned char, unsigned char);
+    uint8_t requestFrom(uint8_t, uint8_t, uint32_t, uint8_t, uint8_t);
     unsigned char requestFrom(int, int);
     unsigned char requestFrom(int, int, int);
     virtual size_t write(unsigned char);


### PR DESCRIPTION
Adding a missing method description to Wire.h allows it to be included in sketches without preventing compilation.