### PR TITLE
Upgrade the .net to 4.6.1 for DevKitTool, which fix the path separato…

### DIFF
--- a/AZ3166/jenkins/DevKitTestTool/App.config
+++ b/AZ3166/jenkins/DevKitTestTool/App.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 
     <appSettings>
@@ -14,7 +14,7 @@
       <add key="DevKitSourceRelativePath" value="devkit-sdk\AZ3166\src"/>
       <add key="InstallPackageBlobUrl" value="https://azureboard.blob.core.windows.net/staging/installpackage/devkit_install_{0}.zip"/>
       <add key="ResultFolder" value="TestResult"/>
-      <add key="PackageName" value="AZ3166-{0}.zip" />
+      <add key="PackageName" value="AZ3166-{0}.zip"/>
       <add key="SystemVersionFilePath" value="devkit-sdk\AZ3166\src\cores\arduino\system\SystemVersion.cpp"/>
       <add key="TelemetryFilePath" value="IoTDevKitInstallation.Win\src\telemetry.js"/>
       <add key="TaskInstallationScriptFilePath" value="IoTDevKitInstallation.Win\src\tasks\task-installation.js"/>

--- a/AZ3166/jenkins/DevKitTestTool/DevKitTestTool.csproj
+++ b/AZ3166/jenkins/DevKitTestTool/DevKitTestTool.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DevKitTestTool</RootNamespace>
     <AssemblyName>DevKitTestTool</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
…r issue

https://stackoverflow.com/questions/27289115/system-io-compression-zipfile-net-4-5-output-zip-in-not-suitable-for-linux-mac