### PR TITLE
Don't log out wifi init error in initIoTDevKit 

### DIFF
--- a/AZ3166/src/libraries/Sensors/src/IoT_DevKit_HW.cpp
+++ b/AZ3166/src/libraries/Sensors/src/IoT_DevKit_HW.cpp
@@ -50,7 +50,6 @@ static bool initWiFi(void)
     }
     else
     {
-        LogError("Failed to initialize Wi-Fi.");
         return -100;
     }
 }


### PR DESCRIPTION
Because the underlying code already print out error information.